### PR TITLE
Switch to username instead email

### DIFF
--- a/server/app.coffee
+++ b/server/app.coffee
@@ -2,14 +2,15 @@ Meteor.startup ->
 
   if 'accounts' of Meteor.settings
     for user in Meteor.settings.accounts
-      existing = Accounts.findUserByEmail user.email
+      existing = Accounts.findUserByUsername user.username
       if existing
-        console.log('Setting password for ', user.email, existing._id)
+        console.log('Setting password for ', user.username, existing._id)
         Accounts.setPassword existing._id, user.password
       else
-        console.log('Creating user ', user.email)
+        console.log('Creating user ', user.username)
         id = Accounts.createUser
-          email: user.email
+          username: user.username
+          email: user.username
           password: user.password
           profile:
             name: user.name


### PR DESCRIPTION
Using emails without '@'s causes the actual logins to use username instead of email so switch to setting username (and email as a copy) to guarantee login will work.